### PR TITLE
Gallery: search transitions by name or author

### DIFF
--- a/packages/website/src/App.jsx
+++ b/packages/website/src/App.jsx
@@ -45,7 +45,8 @@ function EditorRoute() {
 
 function GalleryRoute() {
   const location = useLocation();
-  return <Gallery location={location} />;
+  const navigate = useNavigate();
+  return <Gallery location={location} navigate={navigate} />;
 }
 
 class App extends Component {

--- a/packages/website/src/Gallery.css
+++ b/packages/website/src/Gallery.css
@@ -26,6 +26,43 @@
   padding: 4px;
 }
 
+.gallery .search {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5em;
+  max-width: 400px;
+  margin: 20px auto 0;
+  padding: 0.4em 0.8em;
+  background: #222;
+  border: 1px solid #555;
+  border-radius: 2em;
+  color: #999;
+}
+.gallery .search:focus-within {
+  border-color: #fc6;
+  color: #fc6;
+}
+.gallery .search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #fff;
+  font-size: 1.2em;
+}
+
+.gallery .no-results {
+  text-align: center;
+  padding: 60px 20px;
+  font-size: 1.4em;
+  color: #999;
+}
+.gallery .no-results a {
+  color: #fc6;
+}
+
 .gallery .pager {
   display: flex;
   flex-direction: row;

--- a/packages/website/src/Gallery.jsx
+++ b/packages/website/src/Gallery.jsx
@@ -77,23 +77,49 @@ class PageLink extends PureComponent {
   }
 }
 
+// debounced: each URL change re-renders the grid, remounting costly WebGL contexts
 class SearchInput extends PureComponent {
-  onChange = e => {
+  state = { value: this.props.query.q || "" };
+  timeout = null;
+  componentDidUpdate(prevProps) {
+    const q = this.props.query.q || "";
+    // q changed from outside (Show all, back button): sync the input
+    if (q !== (prevProps.query.q || "") && q !== this.state.value) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
+      this.setState({ value: q });
+    }
+  }
+  componentWillUnmount() {
+    clearTimeout(this.timeout);
+  }
+  apply = () => {
+    clearTimeout(this.timeout);
+    this.timeout = null;
     const { query, navigate } = this.props;
-    navigate(galleryPath({ ...query, q: e.target.value }, 1), {
+    if ((query.q || "") === this.state.value) return;
+    navigate(galleryPath({ ...query, q: this.state.value }, 1), {
       replace: true
     });
   };
+  onChange = e => {
+    this.setState({ value: e.target.value });
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(this.apply, 300);
+  };
+  onKeyDown = e => {
+    if (e.key === "Enter") this.apply();
+  };
   render() {
-    const { query } = this.props;
     return (
       <label className="search">
         <FaSearch />
         <input
           type="search"
           placeholder="Search by name or author…"
-          value={query.q || ""}
+          value={this.state.value}
           onChange={this.onChange}
+          onKeyDown={this.onKeyDown}
         />
       </label>
     );

--- a/packages/website/src/Gallery.jsx
+++ b/packages/website/src/Gallery.jsx
@@ -8,7 +8,7 @@ import Vignette from "./Vignette";
 import dateAgo from "./dateAgo";
 import ScrollToTop from "./ScrollToTop";
 import TransitionAuthorAndName from "./TransitionAuthorAndName";
-import { FaExpand } from "react-icons/fa";
+import { FaExpand, FaSearch } from "react-icons/fa";
 import "./Gallery.css";
 import fromImageUrl from "./images/600x400/barley.jpg";
 import toImageUrl from "./images/600x400/hBd6EPoQT2C8VQYv65ys_White_Sands.jpg";
@@ -54,24 +54,48 @@ class GalleryVignette extends PureComponent {
   }
 }
 
-class VignettePlaceholder extends PureComponent {
-  render() {
-    return (
-      <div style={{ width: 300, height: 200, background: "rgba(0,0,0,0.1)" }} />
-    );
-  }
+function galleryPath(query, page) {
+  const params = new URLSearchParams();
+  if (query.order) params.set("order", query.order);
+  if (query.q) params.set("q", query.q);
+  if (page > 1) params.set("page", page);
+  const search = params.toString();
+  return "/gallery" + (search ? "?" + search : "");
 }
 
 class PageLink extends PureComponent {
   render() {
-    const { page, current, children } = this.props;
+    const { page, current, query, children } = this.props;
     return (
       <Link
         className={page === current ? "active" : ""}
-        to={page === 1 ? "/gallery" : "/gallery?page=" + page}
+        to={galleryPath(query, page)}
       >
         {children}
       </Link>
+    );
+  }
+}
+
+class SearchInput extends PureComponent {
+  onChange = e => {
+    const { query, navigate } = this.props;
+    navigate(galleryPath({ ...query, q: e.target.value }, 1), {
+      replace: true
+    });
+  };
+  render() {
+    const { query } = this.props;
+    return (
+      <label className="search">
+        <FaSearch />
+        <input
+          type="search"
+          placeholder="Search by name or author…"
+          value={query.q || ""}
+          onChange={this.onChange}
+        />
+      </label>
     );
   }
 }
@@ -80,56 +104,66 @@ class PageLink extends PureComponent {
 const pageSize = (navigator.userAgent || "").includes("Android") ? 8 : 12;
 
 function getPage(page, transitions) {
-  const arr = [];
   const from = (page - 1) * pageSize;
-  const to = from + pageSize;
-  for (let i = from; i < to; i++) {
-    arr.push(transitions[i] || null);
-  }
-  return arr;
+  return transitions.slice(from, from + pageSize);
+}
+
+function searchTransitions(transitions, q) {
+  const s = q.toLowerCase();
+  return transitions.filter(
+    t =>
+      t.name.toLowerCase().includes(s) ||
+      (t.author || "").toLowerCase().includes(s)
+  );
 }
 
 export default class Gallery extends Component {
   render() {
-    const { location } = this.props;
+    const { location, navigate } = this.props;
     const query = Object.fromEntries(
       new URLSearchParams(location.search || "")
     );
     const page = !isNaN(query.page) ? parseInt(query.page, 10) : 1;
     const order = query.order;
-    const transitions =
+    const q = (query.q || "").trim();
+    const all =
       order === "updated"
         ? transitionsOrderByUpdatedAt
         : transitionsOrderByCreatedAt;
+    const transitions = q ? searchTransitions(all, q) : all;
     const nbPages = Math.ceil(transitions.length / pageSize);
     const pagination = Array(nbPages) // the time we have too much pages we refactor this xD
       .fill(null)
       .map((_, i) => i + 1)
       .map(p => (
-        <PageLink key={p} page={p} current={page}>
+        <PageLink key={p} page={p} current={page} query={query}>
           {p}
         </PageLink>
       ));
     return (
       <ScrollToTop>
         <div className="gallery">
+          <SearchInput query={query} navigate={navigate} />
           <div className="pager">{pagination}</div>
-          <div className="transitions">
-            {getPage(page, transitions).map((transition, i) =>
-              transition ? (
+          {transitions.length === 0 ? (
+            <div className="no-results">
+              No transition matches “{q}”.{" "}
+              <Link to="/gallery">Show all</Link>
+            </div>
+          ) : (
+            <div className="transitions">
+              {getPage(page, transitions).map(transition => (
                 <GalleryVignette
-                  key={i}
+                  key={transition.name}
                   transition={transition}
                   order={order}
                 />
-              ) : (
-                <VignettePlaceholder key={i} />
-              )
-            )}
-          </div>
+              ))}
+            </div>
+          )}
           <div className="pager">
             {page === nbPages && page !== 1 ? (
-              <PageLink page={1} current={page}>
+              <PageLink page={1} current={page} query={query}>
                 Back to First Page
               </PageLink>
             ) : (


### PR DESCRIPTION
Adds a search box to the gallery page (issue #28).

- Typing filters transitions by **name or author** (case-insensitive substring).
- **Debounced (300ms)**: the grid remounts costly WebGL contexts on each re-render, so the input is locally controlled and only pushes the query to the URL after a pause. Enter flushes immediately; external URL changes (Show all, back button) sync back into the input.
- The query lives in the URL (`/gallery?q=cube`) so searches are shareable/bookmarkable; applying a search resets to page 1 and uses `replace` navigation to avoid history spam.
- Pagination links now preserve `q` and `order` (previously even `order` was dropped when changing page).
- Empty results show a "No transition matches" message with a *Show all* link.
- Short pages are no longer padded with gray placeholder boxes — with few search results they looked broken.
- Vignettes are keyed by transition name, so results staying visible across query changes keep their GL context.

Verified in the running app (Playwright + SwiftShader): filtering, URL sync, author search, page links preserving the query, `order=updated` preserved while typing, special-character queries, zero URL changes while typing fast (exactly one after settling), Enter flush, and the type-then-Show-all race within the debounce window.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)