### PR TITLE
Use npm trusted publishing (OIDC) for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - name: Upgrade npm for trusted publishing (needs >= 11.5.1, Node 22 ships 10)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11 && npm --version
       - name: Install headless-gl system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      - name: Upgrade npm for trusted publishing (needs >= 11.5.1, Node 22 ships 10)
+        run: npm install -g npm@latest
       - name: Install headless-gl system dependencies
         run: |
           sudo apt-get update
@@ -34,4 +36,3 @@ jobs:
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Replicates the gre/gl-react setup: no `NPM_TOKEN` secret needed — the `id-token: write` permission (already present) lets npm authenticate via OIDC trusted publishing.

The previous release run failed with `ENEEDAUTH` because `NPM_TOKEN` was never set and Node 22 ships npm 10, which predates trusted publishing support (requires npm >= 11.5.1). `changesets/action@v1` already takes the OIDC path when `NPM_TOKEN` is absent.

Changes:
- upgrade global npm before publishing (changesets shells out to `npm publish`)
- drop the dead `NPM_TOKEN` env reference

⚠️ Before merging, the trusted publisher must be configured on npmjs.com for each of the 5 packages (`gl-transition`, `gl-transition-utils`, `gl-transition-scripts`, `react-gl-transition`, `regl-transition`): package Settings → Trusted Publisher → GitHub Actions, repo `gre/gl-transition-libs`, workflow `release.yml`, environment left empty.

Once merged, the Release workflow re-runs on master and publishes the pending 2.0.0 versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)